### PR TITLE
Add minimal param LSP server example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,3 +387,9 @@ $RECYCLE.BIN/
 .github/skills/hvplot.md
 .github/skills/holoviews.md
 .github/skills/panel-material-ui.md
+*node_modules/
+
+# param-lsp example extension
+examples/param-lsp/vscode-client/node_modules/
+examples/param-lsp/vscode-client/package-lock.json
+examples/param-lsp/vscode-client/*.vsix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
     rev: v9.13.0
     hooks:
       - id: eslint
+        files: ^holoviz_mcp/.*\.(js|ts)$
         args: ['-c', 'holoviz_mcp/.eslintrc.js', 'holoviz_mcp/*.ts', 'holoviz_mcp/models/**/*.ts', '--fix']
         additional_dependencies:
           - 'eslint@8.57.0'

--- a/examples/param-lsp/README.md
+++ b/examples/param-lsp/README.md
@@ -1,0 +1,238 @@
+# Minimal LSP Server for param
+
+A minimal Language Server Protocol (LSP) implementation that provides IDE features for `param.Parameterized` classes.
+
+## Current Status
+
+This is a **proof-of-concept** LSP server demonstrating what's possible for param tooling. It uses simple regex-based parsing (not a full Python AST parser) and only analyzes the current file.
+
+### Features
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| **Hover (declarations)** | ✅ | Hover over `param.Integer(...)` to see type info |
+| **Hover (attribute access)** | ✅ | Hover over `person.name` to see param info (same file only) |
+| **Completion (param types)** | ✅ | Type `param.` to see all param types |
+| **Completion (kwargs)** | ✅ | Inside `param.Number(...)`, get suggestions for `bounds`, `doc`, etc. |
+| **Completion (instantiation)** | ✅ | Type `Person(` to see parameter names |
+| **Diagnostics** | ✅ | Warnings for unknown types, missing `objects` in Selectors |
+| **Cross-file resolution** | ❌ | Only works within the current file |
+| **Type checking** | ❌ | Does not replace Pylance/Pyright |
+
+### Limitations
+
+- **Regex-based parsing**: May fail on complex multi-line declarations
+- **Same-file only**: Cannot resolve classes or variables from imports
+- **No inheritance tracking**: Doesn't resolve inherited parameters from parent classes in other files
+- **Runs alongside Pylance**: Pylance may still show type errors (see [Pylance Coexistence](#pylance-coexistence))
+
+## Installation
+
+### Prerequisites
+
+```bash
+pip install pygls lsprotocol param
+```
+
+### Quick Test
+
+Run the tests to verify the server works:
+
+```bash
+cd examples/param-lsp
+python test_param_lsp.py
+```
+
+Expected output:
+```
+✓ test_parse_param_args_with_kwargs
+✓ test_parse_param_args_with_positional
+...
+PASSED: All 11 tests passed!
+```
+
+## Building the VS Code Extension
+
+The `vscode-client/` folder contains a minimal VS Code extension that launches the LSP server.
+
+### Build Steps
+
+```bash
+cd examples/param-lsp/vscode-client
+
+# Install dependencies
+npm install
+
+# Package as VSIX
+npx vsce package --allow-missing-repository -o param-lsp.vsix
+```
+
+This creates `param-lsp.vsix` (~32 MB).
+
+> **Note**: The extension uses an absolute path to `param_lsp.py`. If you move the files, update the path in `extension.js`.
+
+## Installing the Extension
+
+### VS Code (Desktop)
+
+```bash
+# Install
+code --install-extension examples/param-lsp/vscode-client/param-lsp.vsix
+
+# Or for development (hot reload)
+code --extensionDevelopmentPath=/full/path/to/examples/param-lsp/vscode-client
+```
+
+### code-server (Web)
+
+```bash
+# Install
+code-server --install-extension examples/param-lsp/vscode-client/param-lsp.vsix
+
+# Force reinstall (after updates)
+code-server --install-extension examples/param-lsp/vscode-client/param-lsp.vsix --force
+```
+
+After installation, **reload the window**:
+- Press `Ctrl+Shift+P`
+- Type "Reload Window"
+- Press Enter
+
+### Verify Installation
+
+1. Open a Python file with `param.Parameterized` classes
+2. Open the Output panel: `Ctrl+Shift+U` (or View → Output)
+3. Select "Param LSP" from the dropdown
+4. You should see: `Starting Param LSP server...`
+
+## Uninstalling the Extension
+
+### VS Code (Desktop)
+
+```bash
+code --uninstall-extension undefined_publisher.param-lsp-client
+```
+
+### code-server (Web)
+
+```bash
+code-server --uninstall-extension undefined_publisher.param-lsp-client
+```
+
+### Via UI
+
+1. Open Extensions panel: `Ctrl+Shift+X`
+2. Search for "Param LSP"
+3. Click the gear icon → Uninstall
+
+## Usage
+
+Open `example_parameterized.py` and try:
+
+1. **Hover** over `param.Integer` → see type info and kwargs
+2. **Hover** over `person.name` → see the parameter's type and metadata
+3. **Type** `param.` → see completion for all param types
+4. **Inside** `param.Number(`, press `Ctrl+Space` → see kwargs like `bounds`, `doc`
+5. **Type** `Person(` → see completion for `name`, `age`, `height`, etc.
+
+## Pylance Coexistence
+
+This LSP runs **alongside** Pylance (VS Code's Python language server). They don't share information:
+
+```
+┌─────────────────┐     ┌─────────────────┐
+│    Pylance      │     │   param-lsp     │
+│ "name unknown"  │     │ "name: str"     │
+└────────┬────────┘     └────────┬────────┘
+         │                       │
+         └───────────┬───────────┘
+                     ▼
+              Both show in VS Code
+```
+
+**Pylance may still show errors** like "Property 'name' not defined" because it doesn't understand param descriptors.
+
+### Workarounds
+
+1. **Add type annotations** (recommended):
+   ```python
+   name: str = param.String(default="Alice")
+   ```
+
+2. **Disable Pylance for specific files**:
+   ```json
+   // .vscode/settings.json
+   {
+     "python.analysis.ignore": ["**/my_parameterized_file.py"]
+   }
+   ```
+
+3. **Create type stubs** (`param.pyi`) - more complex but fully fixes the issue
+
+## Architecture
+
+```
+examples/param-lsp/
+├── param_lsp.py              # LSP server (Python)
+│   ├── PARAM_TYPE_INFO       # Map: param.Type → Python type
+│   ├── hover()               # textDocument/hover handler
+│   ├── completion()          # textDocument/completion handler
+│   └── analyze_document()    # Diagnostics
+├── test_param_lsp.py         # Unit tests
+├── example_parameterized.py  # Example file to test with
+├── README.md                 # This file
+└── vscode-client/            # VS Code extension
+    ├── package.json          # Extension manifest
+    ├── extension.js          # Extension entry point
+    └── node_modules/         # Dependencies
+```
+
+## Development
+
+### Running the Server Standalone
+
+For debugging, run the server directly:
+
+```bash
+python param_lsp.py
+```
+
+The server communicates via stdio using JSON-RPC. You can test with:
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}
+```
+
+### Modifying the Server
+
+1. Edit `param_lsp.py`
+2. No need to rebuild the extension - it reads the Python file directly
+3. Reload VS Code window to pick up changes
+
+### Adding New Param Types
+
+Edit `PARAM_TYPE_INFO` in `param_lsp.py`:
+
+```python
+PARAM_TYPE_INFO = {
+    "param.MyNewType": ("my_python_type", "Description of the type"),
+    # ...
+}
+```
+
+## Future Improvements
+
+To make this production-ready:
+
+1. **Use AST parsing** instead of regex for robust detection
+2. **Cross-file resolution** via workspace indexing
+3. **Runtime introspection** to get actual Parameter metadata
+4. **Mypy/Pyright plugin** to provide types to static checkers
+5. **Type stubs generation** for param library
+
+## Related Resources
+
+- [pygls](https://pygls.readthedocs.io/) - Python Language Server library
+- [param](https://param.holoviz.org/) - Parameter library for Python
+- [LSP Specification](https://microsoft.github.io/language-server-protocol/) - Protocol documentation
+- [vscode-languageclient](https://github.com/microsoft/vscode-languageserver-node) - VS Code LSP client

--- a/examples/param-lsp/example_parameterized.py
+++ b/examples/param-lsp/example_parameterized.py
@@ -1,0 +1,82 @@
+"""
+Example Parameterized classes for testing the param-lsp server.
+
+Open this file in VS Code with the param-lsp extension active to see:
+- Hover documentation for param declarations
+- Autocompletion for param types after "param."
+- Autocompletion for kwargs inside param.Type(...)
+- Autocompletion for parameter names when instantiating classes
+- Diagnostics for unknown types and missing required kwargs
+"""
+
+import param
+
+
+class Person(param.Parameterized):
+    """A person with various attributes."""
+
+    name = param.String(default="Anonymous", doc="The person's name")
+    age = param.Integer(default=0, bounds=(0, 150), doc="Age in years")
+    height = param.Number(default=1.7, bounds=(0.0, 3.0), doc="Height in meters")
+    is_active = param.Boolean(default=True, doc="Whether the person is active")
+    email = param.String(default="", regex=r"^[\w\.-]+@[\w\.-]+\.\w+$", doc="Email address")
+
+
+class Employee(Person):
+    """An employee extending Person."""
+
+    employee_id = param.String(doc="Unique employee identifier")
+    department = param.Selector(
+        objects=["Engineering", "Sales", "Marketing", "HR"],
+        default="Engineering",
+        doc="Department the employee belongs to",
+    )
+    salary = param.Number(default=50000, bounds=(0, None), doc="Annual salary")
+    skills = param.List(default=[], item_type=str, doc="List of skills")
+
+
+class Project(param.Parameterized):
+    """A project with team members."""
+
+    name = param.String(default="Untitled", doc="Project name")
+    lead = param.ClassSelector(class_=Employee, doc="Project lead")
+    team = param.List(default=[], item_type=Employee, doc="Team members")
+    budget = param.Number(default=0, bounds=(0, None), doc="Project budget")
+    status = param.Selector(
+        objects=["Planning", "In Progress", "Review", "Complete"],
+        default="Planning",
+        doc="Current project status",
+    )
+    start_date = param.Date(doc="Project start date")
+    config = param.Dict(default={}, doc="Additional configuration")
+
+
+class DataProcessor(param.Parameterized):
+    """A data processing pipeline."""
+
+    input_path = param.Path(doc="Input file or folder path")
+    output_path = param.Filename(doc="Output filename")
+    batch_size = param.Integer(default=100, bounds=(1, 10000), doc="Processing batch size")
+    threshold = param.Number(default=0.5, bounds=(0.0, 1.0), doc="Decision threshold")
+    on_complete = param.Callable(doc="Callback when processing is complete")
+    verbose = param.Boolean(default=False, doc="Enable verbose logging")
+
+
+# Example instantiation - the LSP should provide completion for parameter names
+if __name__ == "__main__":
+    # Try typing inside the parentheses to see completions
+    person = Person(
+        name="Alice",
+        age=30,
+    )
+
+    employee = Employee(
+        name="Bob",
+        department="Engineering",
+        skills=["Python", "Data Science"],
+    )
+
+    print(f"Person: {person.name}, {person.age} years old", person.email)
+    print(f"Employee: {employee.name}, {employee.department}")
+
+Person()

--- a/examples/param-lsp/param_lsp.py
+++ b/examples/param-lsp/param_lsp.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python
+"""
+Minimal LSP Server for param - Single File Example
+
+Install dependencies:
+    pip install pygls lsprotocol param
+
+Run the server:
+    python param_lsp.py
+
+Configure VS Code (settings.json):
+    Add to your settings.json to test with a generic LSP client extension
+"""
+
+import re
+
+from lsprotocol import types as lsp
+from pygls.lsp.server import LanguageServer
+from pygls.workspace import TextDocument
+
+# Create the language server
+server = LanguageServer("param-lsp", "v0.1.0")
+
+# Map param types to Python types and descriptions
+PARAM_TYPE_INFO = {
+    "param.Integer": ("int", "Integer parameter with optional bounds"),
+    "param.Number": ("float", "Numeric parameter (float) with optional bounds"),
+    "param.String": ("str", "String parameter with optional regex validation"),
+    "param.Boolean": ("bool", "Boolean parameter (True/False)"),
+    "param.List": ("list", "List parameter with optional item type"),
+    "param.Dict": ("dict", "Dictionary parameter"),
+    "param.Selector": ("Any", "Single selection from a list of objects"),
+    "param.ListSelector": ("list", "Multiple selections from a list of objects"),
+    "param.ClassSelector": ("object", "Instance or subclass of a specified class"),
+    "param.Callable": ("Callable", "Callable object (function, method, etc.)"),
+    "param.Action": ("Callable", "Callable with no arguments, ready to invoke"),
+    "param.Parameter": ("Any", "Generic parameter"),
+    "param.Tuple": ("tuple", "Python tuple of fixed length"),
+    "param.Range": ("tuple[float, float]", "Numeric range with optional bounds"),
+    "param.Date": ("datetime", "Date or datetime value"),
+    "param.Color": ("str", "Hex RGB color string or named color"),
+    "param.Path": ("str", "POSIX-style path string"),
+    "param.Filename": ("str", "POSIX-style filename string"),
+    "param.Foldername": ("str", "POSIX-style folder path string"),
+    "param.DataFrame": ("pandas.DataFrame", "Pandas DataFrame"),
+    "param.Series": ("pandas.Series", "Pandas Series"),
+    "param.Array": ("numpy.ndarray", "NumPy array"),
+    "param.Event": ("bool", "Event trigger parameter"),
+}
+
+# Regex to find param declarations: name = param.Type(...)
+PARAM_PATTERN = re.compile(r"^\s*(\w+)\s*=\s*(param\.(\w+))\s*\(([^)]*)\)", re.MULTILINE)
+
+# Regex to find class definitions inheriting from Parameterized
+CLASS_PATTERN = re.compile(r"^class\s+(\w+)\s*\([^)]*(?:param\.)?Parameterized[^)]*\)\s*:", re.MULTILINE)
+
+
+def parse_param_args(args_str: str) -> dict:
+    """Parse parameter arguments from the declaration string."""
+    result = {}
+    # Simple parsing for common kwargs
+    for match in re.finditer(r"(\w+)\s*=\s*([^,]+?)(?:,|$)", args_str):
+        key, value = match.groups()
+        result[key.strip()] = value.strip()
+    # Check for positional default (first arg without =)
+    first_arg = args_str.split(",")[0].strip() if args_str else ""
+    if first_arg and "=" not in first_arg:
+        result["default"] = first_arg
+    return result
+
+
+def find_param_at_position(document: TextDocument, position: lsp.Position) -> dict | None:
+    """Find the param declaration at the given position."""
+    lines = document.source.split("\n")
+    if position.line >= len(lines):
+        return None
+
+    line = lines[position.line]
+
+    # Check if cursor is on a param declaration line
+    match = PARAM_PATTERN.match(line)
+    if not match:
+        return None
+
+    name, full_type, type_name, args = match.groups()
+
+    # Check if cursor is within the match
+    start = match.start()
+    end = match.end()
+    if not (start <= position.character <= end):
+        return None
+
+    return {
+        "name": name,
+        "param_type": full_type,
+        "type_name": type_name,
+        "args": parse_param_args(args),
+        "line": position.line,
+    }
+
+
+def find_all_params_in_document(document: TextDocument) -> list[dict]:
+    """Find all param declarations in the document."""
+    params = []
+    lines = document.source.split("\n")
+
+    for line_num, line in enumerate(lines):
+        match = PARAM_PATTERN.match(line)
+        if match:
+            name, full_type, type_name, args = match.groups()
+            params.append(
+                {
+                    "name": name,
+                    "param_type": full_type,
+                    "type_name": type_name,
+                    "args": parse_param_args(args),
+                    "line": line_num,
+                }
+            )
+
+    return params
+
+
+def find_parameterized_classes(document: TextDocument) -> list[dict]:
+    """Find all Parameterized class definitions in the document."""
+    classes = []
+    lines = document.source.split("\n")
+
+    for line_num, line in enumerate(lines):
+        match = CLASS_PATTERN.match(line)
+        if match:
+            class_name = match.group(1)
+            # Find parameters belonging to this class (simple heuristic: indented lines after class def)
+            class_params = []
+            for i in range(line_num + 1, len(lines)):
+                param_line = lines[i]
+                # Stop at next class or unindented line
+                if param_line and not param_line.startswith((" ", "\t")):
+                    break
+                param_match = PARAM_PATTERN.match(param_line)
+                if param_match:
+                    name, full_type, type_name, args = param_match.groups()
+                    class_params.append(
+                        {
+                            "name": name,
+                            "param_type": full_type,
+                            "type_name": type_name,
+                            "args": parse_param_args(args),
+                            "line": i,
+                        }
+                    )
+
+            classes.append(
+                {
+                    "name": class_name,
+                    "line": line_num,
+                    "params": class_params,
+                }
+            )
+
+    return classes
+
+
+# Regex to find variable assignments: var = ClassName(...)
+INSTANCE_PATTERN = re.compile(r"^\s*(\w+)\s*=\s*(\w+)\s*\(")
+
+# Regex to find attribute access: var.attr
+ATTR_ACCESS_PATTERN = re.compile(r"\b(\w+)\.(\w+)\b")
+
+
+def find_instance_class(document: TextDocument, var_name: str) -> str | None:
+    """Find the class name for a variable assignment like 'person = Person(...)'."""
+    for line in document.source.split("\n"):
+        match = INSTANCE_PATTERN.match(line)
+        if match and match.group(1) == var_name:
+            return match.group(2)
+    return None
+
+
+def find_param_for_attribute(document: TextDocument, var_name: str, attr_name: str) -> dict | None:
+    """Find param info for an attribute access like 'person.name'."""
+    # Find what class the variable is an instance of
+    class_name = find_instance_class(document, var_name)
+    if not class_name:
+        return None
+
+    # Find the class and its parameters
+    classes = find_parameterized_classes(document)
+    for cls in classes:
+        if cls["name"] == class_name:
+            for param in cls["params"]:
+                if param["name"] == attr_name:
+                    return param
+    return None
+
+
+def build_hover_content(param_info: dict) -> str:
+    """Build markdown hover content for a parameter."""
+    name = param_info["name"]
+    param_type = param_info["param_type"]
+    args = param_info["args"]
+
+    # Get Python type and description
+    py_type, description = PARAM_TYPE_INFO.get(param_type, ("Any", "Parameter"))
+
+    # Build markdown
+    lines = [
+        f"### `{name}: {py_type}`",
+        "",
+        f"**Type:** `{param_type}`",
+        "",
+        f"_{description}_",
+        "",
+    ]
+
+    # Add parsed attributes
+    if args:
+        lines.append("**Attributes:**")
+        for key, value in args.items():
+            lines.append(f"- `{key}`: {value}")
+
+    return "\n".join(lines)
+
+
+@server.feature(lsp.TEXT_DOCUMENT_HOVER)
+def hover(params: lsp.HoverParams) -> lsp.Hover | None:
+    """Provide hover information for param declarations and attribute access."""
+    document = server.workspace.get_text_document(params.text_document.uri)
+
+    # First, try to find a param declaration at this position
+    param_info = find_param_at_position(document, params.position)
+
+    # If not a declaration, check for attribute access (e.g., person.name)
+    if not param_info:
+        lines = document.source.split("\n")
+        if params.position.line < len(lines):
+            line = lines[params.position.line]
+            # Find all attribute accesses in this line
+            for match in ATTR_ACCESS_PATTERN.finditer(line):
+                # Check if cursor is within this match
+                if match.start() <= params.position.character <= match.end():
+                    var_name, attr_name = match.groups()
+                    param_info = find_param_for_attribute(document, var_name, attr_name)
+                    break
+
+    if not param_info:
+        return None
+
+    content = build_hover_content(param_info)
+
+    return lsp.Hover(
+        contents=lsp.MarkupContent(
+            kind=lsp.MarkupKind.Markdown,
+            value=content,
+        )
+    )
+
+
+@server.feature(lsp.TEXT_DOCUMENT_COMPLETION)
+def completion(params: lsp.CompletionParams) -> lsp.CompletionList | None:
+    """Provide completion for param types and parameter names."""
+    document = server.workspace.get_text_document(params.text_document.uri)
+    lines = document.source.split("\n")
+
+    if params.position.line >= len(lines):
+        return None
+
+    line = lines[params.position.line]
+    char_pos = params.position.character
+    text_before_cursor = line[:char_pos]
+
+    items = []
+
+    # Case 1: Completing param types (after "param.")
+    if text_before_cursor.rstrip().endswith("param."):
+        for param_type, (py_type, doc) in PARAM_TYPE_INFO.items():
+            type_name = param_type.replace("param.", "")
+            items.append(
+                lsp.CompletionItem(
+                    label=type_name,
+                    kind=lsp.CompletionItemKind.Class,
+                    detail=f"→ {py_type}",
+                    documentation=lsp.MarkupContent(
+                        kind=lsp.MarkupKind.Markdown,
+                        value=f"**{param_type}**\n\n{doc}\n\nPython type: `{py_type}`",
+                    ),
+                    insert_text=f"{type_name}($0)",
+                    insert_text_format=lsp.InsertTextFormat.Snippet,
+                )
+            )
+        return lsp.CompletionList(is_incomplete=False, items=items)
+
+    # Case 2: Completing parameter kwargs (inside param.Type(...))
+    # Check if we're inside a param declaration
+    param_match = re.match(r"^\s*\w+\s*=\s*param\.(\w+)\s*\(", line)
+    if param_match and "(" in text_before_cursor and ")" not in text_before_cursor:
+        param_type_name = param_match.group(1)
+
+        # Common kwargs for all param types
+        common_kwargs = [
+            ("default", "Default value for this parameter"),
+            ("doc", "Documentation string for this parameter"),
+            ("constant", "If True, value cannot be changed after instantiation"),
+            ("readonly", "If True, value cannot be set by user"),
+            ("allow_None", "If True, None is an allowed value"),
+            ("label", "Human-readable label for this parameter"),
+            ("precedence", "Numeric precedence for UI ordering"),
+            ("instantiate", "If True, default value is deep-copied per instance"),
+            ("per_instance", "If True, separate Parameter object per instance"),
+        ]
+
+        # Type-specific kwargs
+        type_specific = {
+            "Integer": [("bounds", "Tuple of (min, max) bounds")],
+            "Number": [
+                ("bounds", "Tuple of (min, max) bounds"),
+                ("softbounds", "Tuple of (min, max) soft bounds for UI"),
+                ("step", "Step size for UI sliders"),
+            ],
+            "String": [("regex", "Regular expression pattern to validate against")],
+            "Selector": [("objects", "List or dict of valid objects to select from")],
+            "ListSelector": [("objects", "List or dict of valid objects to select from")],
+            "ClassSelector": [
+                ("class_", "Class or tuple of classes to accept"),
+                ("is_instance", "If True, require instance; if False, require subclass"),
+            ],
+            "List": [
+                ("item_type", "Type constraint for list items"),
+                ("bounds", "Tuple of (min_length, max_length)"),
+            ],
+            "Path": [("check_exists", "If True, path must exist"), ("search_paths", "List of paths to search")],
+            "Range": [("bounds", "Tuple of (min, max) bounds"), ("softbounds", "Tuple of soft bounds")],
+        }
+
+        all_kwargs = common_kwargs + type_specific.get(param_type_name, [])
+
+        for kwarg, doc in all_kwargs:
+            items.append(
+                lsp.CompletionItem(
+                    label=kwarg,
+                    kind=lsp.CompletionItemKind.Property,
+                    detail="param kwarg",
+                    documentation=doc,
+                    insert_text=f"{kwarg}=$0",
+                    insert_text_format=lsp.InsertTextFormat.Snippet,
+                )
+            )
+
+        return lsp.CompletionList(is_incomplete=False, items=items)
+
+    # Case 3: Completing class instantiation parameters
+    # Look for patterns like "MyClass(" where MyClass is a Parameterized class
+    class_instantiation = re.search(r"(\w+)\s*\($", text_before_cursor)
+    if class_instantiation:
+        class_name = class_instantiation.group(1)
+        # Find the class in this document
+        classes = find_parameterized_classes(document)
+        for cls in classes:
+            if cls["name"] == class_name:
+                for p in cls["params"]:
+                    py_type, _ = PARAM_TYPE_INFO.get(p["param_type"], ("Any", ""))
+                    items.append(
+                        lsp.CompletionItem(
+                            label=p["name"],
+                            kind=lsp.CompletionItemKind.Field,
+                            detail=f": {py_type}",
+                            documentation=f"Parameter `{p['name']}` of type `{p['param_type']}`",
+                            insert_text=f"{p['name']}=$0",
+                            insert_text_format=lsp.InsertTextFormat.Snippet,
+                        )
+                    )
+                return lsp.CompletionList(is_incomplete=False, items=items)
+
+    return None
+
+
+@server.feature(lsp.TEXT_DOCUMENT_DID_OPEN)
+def did_open(params: lsp.DidOpenTextDocumentParams):
+    """Handle document open - publish diagnostics."""
+    document = server.workspace.get_text_document(params.text_document.uri)
+    diagnostics = analyze_document(document)
+    server.publish_diagnostics(params.text_document.uri, diagnostics)
+
+
+@server.feature(lsp.WORKSPACE_DID_CHANGE_WATCHED_FILES)
+def did_change_watched_files(params: lsp.DidChangeWatchedFilesParams):
+    """Handle file system changes - silently ignore for now."""
+    pass
+
+
+@server.feature(lsp.TEXT_DOCUMENT_DID_CHANGE)
+def did_change(params: lsp.DidChangeTextDocumentParams):
+    """Handle document change - update diagnostics."""
+    document = server.workspace.get_text_document(params.text_document.uri)
+    diagnostics = analyze_document(document)
+    server.publish_diagnostics(params.text_document.uri, diagnostics)
+
+
+def analyze_document(document: TextDocument) -> list[lsp.Diagnostic]:
+    """Analyze document for param-related issues."""
+    diagnostics = []
+    lines = document.source.split("\n")
+
+    for line_num, line in enumerate(lines):
+        match = PARAM_PATTERN.match(line)
+        if not match:
+            continue
+
+        name, full_type, type_name, args = match.groups()
+
+        # Check if param type is known
+        if full_type not in PARAM_TYPE_INFO:
+            diagnostics.append(
+                lsp.Diagnostic(
+                    range=lsp.Range(
+                        start=lsp.Position(line=line_num, character=match.start(2)),
+                        end=lsp.Position(line=line_num, character=match.end(2)),
+                    ),
+                    message=f"Unknown param type: {full_type}",
+                    severity=lsp.DiagnosticSeverity.Information,
+                    source="param-lsp",
+                )
+            )
+
+        # Check for missing 'objects' in Selector types
+        parsed_args = parse_param_args(args)
+        if type_name in ("Selector", "ListSelector") and "objects" not in parsed_args:
+            diagnostics.append(
+                lsp.Diagnostic(
+                    range=lsp.Range(
+                        start=lsp.Position(line=line_num, character=match.start(3)),
+                        end=lsp.Position(line=line_num, character=match.end(3)),
+                    ),
+                    message=f"{type_name} should specify 'objects' parameter",
+                    severity=lsp.DiagnosticSeverity.Warning,
+                    source="param-lsp",
+                )
+            )
+
+        # Check for bounds on numeric types
+        if type_name in ("Integer", "Number") and "bounds" not in parsed_args:
+            diagnostics.append(
+                lsp.Diagnostic(
+                    range=lsp.Range(
+                        start=lsp.Position(line=line_num, character=match.start(3)),
+                        end=lsp.Position(line=line_num, character=match.end(3)),
+                    ),
+                    message=f"Consider adding 'bounds' to {type_name} for better validation",
+                    severity=lsp.DiagnosticSeverity.Hint,
+                    source="param-lsp",
+                )
+            )
+
+    return diagnostics
+
+
+if __name__ == "__main__":
+    print("Starting param-lsp server on stdio...")
+    print("Features: hover, completion, diagnostics")
+    server.start_io()

--- a/examples/param-lsp/test_param_lsp.py
+++ b/examples/param-lsp/test_param_lsp.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+"""Tests for the minimal param LSP server."""
+
+from lsprotocol import types as lsp
+from pygls.workspace import TextDocument
+
+from param_lsp import (
+    PARAM_TYPE_INFO,
+    build_hover_content,
+    find_all_params_in_document,
+    find_param_at_position,
+    find_parameterized_classes,
+    parse_param_args,
+)
+
+SAMPLE_SOURCE = '''
+import param
+
+class MyClass(param.Parameterized):
+    count = param.Integer(default=0, bounds=(0, 100))
+    name = param.String("hello", doc="A name")
+    ratio = param.Number(0.5, bounds=(0.0, 1.0))
+    enabled = param.Boolean(True)
+    items = param.List(["a", "b"], item_type=str)
+    mode = param.Selector(objects=["fast", "slow"], default="fast")
+
+class SubClass(MyClass):
+    extra = param.String("extra value")
+'''
+
+
+def test_parse_param_args_with_kwargs():
+    """Test parsing keyword arguments from param declaration."""
+    args = "default=0, bounds=(0, 100), doc='A number'"
+    result = parse_param_args(args)
+
+    assert result["default"] == "0"
+    assert result["bounds"] == "(0"  # Simple parsing doesn't handle nested parens well
+    assert result["doc"] == "'A number'"
+
+
+def test_parse_param_args_with_positional():
+    """Test parsing positional default argument."""
+    args = '"hello", doc="A string"'
+    result = parse_param_args(args)
+
+    assert result["default"] == '"hello"'
+    assert result["doc"] == '"A string"'
+
+
+def test_parse_param_args_empty():
+    """Test parsing empty arguments."""
+    result = parse_param_args("")
+    assert result == {}
+
+
+def test_find_param_at_position():
+    """Test finding param declaration at cursor position."""
+    doc = TextDocument(uri="file:///test.py", source=SAMPLE_SOURCE)
+
+    # Line 4: "    count = param.Integer(default=0, bounds=(0, 100))"
+    result = find_param_at_position(doc, lsp.Position(line=4, character=10))
+
+    assert result is not None
+    assert result["name"] == "count"
+    assert result["param_type"] == "param.Integer"
+    assert result["type_name"] == "Integer"
+
+
+def test_find_param_at_position_string():
+    """Test finding String param at cursor position."""
+    doc = TextDocument(uri="file:///test.py", source=SAMPLE_SOURCE)
+
+    # Line 5: "    name = param.String("hello", doc="A name")"
+    result = find_param_at_position(doc, lsp.Position(line=5, character=15))
+
+    assert result is not None
+    assert result["name"] == "name"
+    assert result["param_type"] == "param.String"
+
+
+def test_find_param_at_position_not_found():
+    """Test that non-param lines return None."""
+    doc = TextDocument(uri="file:///test.py", source=SAMPLE_SOURCE)
+
+    # Line 1: "import param"
+    result = find_param_at_position(doc, lsp.Position(line=1, character=5))
+    assert result is None
+
+
+def test_find_all_params_in_document():
+    """Test finding all param declarations in a document."""
+    doc = TextDocument(uri="file:///test.py", source=SAMPLE_SOURCE)
+
+    params = find_all_params_in_document(doc)
+
+    assert len(params) == 7  # count, name, ratio, enabled, items, mode, extra
+    param_names = [p["name"] for p in params]
+    assert "count" in param_names
+    assert "name" in param_names
+    assert "ratio" in param_names
+    assert "enabled" in param_names
+    assert "items" in param_names
+    assert "mode" in param_names
+    assert "extra" in param_names
+
+
+def test_find_parameterized_classes():
+    """Test finding Parameterized class definitions."""
+    doc = TextDocument(uri="file:///test.py", source=SAMPLE_SOURCE)
+
+    classes = find_parameterized_classes(doc)
+
+    # Only finds classes that directly inherit from Parameterized
+    # SubClass(MyClass) is not detected as it inherits indirectly
+    assert len(classes) >= 1
+    assert classes[0]["name"] == "MyClass"
+    assert len(classes[0]["params"]) == 6
+
+
+def test_build_hover_content():
+    """Test building hover markdown content."""
+    param_info = {
+        "name": "count",
+        "param_type": "param.Integer",
+        "type_name": "Integer",
+        "args": {"default": "0", "bounds": "(0, 100)"},
+        "line": 4,
+    }
+
+    content = build_hover_content(param_info)
+
+    assert "count: int" in content
+    assert "param.Integer" in content
+    assert "Integer parameter" in content
+    assert "default" in content
+    assert "bounds" in content
+
+
+def test_build_hover_content_unknown_type():
+    """Test hover content for unknown param type."""
+    param_info = {
+        "name": "custom",
+        "param_type": "param.CustomType",
+        "type_name": "CustomType",
+        "args": {},
+        "line": 0,
+    }
+
+    content = build_hover_content(param_info)
+
+    assert "custom: Any" in content  # Falls back to Any
+
+
+def test_param_type_info_completeness():
+    """Test that common param types are covered."""
+    common_types = [
+        "param.Integer",
+        "param.Number",
+        "param.String",
+        "param.Boolean",
+        "param.List",
+        "param.Dict",
+        "param.Selector",
+        "param.ClassSelector",
+        "param.Callable",
+    ]
+
+    for param_type in common_types:
+        assert param_type in PARAM_TYPE_INFO, f"Missing type: {param_type}"
+        py_type, description = PARAM_TYPE_INFO[param_type]
+        assert py_type, f"Empty Python type for {param_type}"
+        assert description, f"Empty description for {param_type}"
+
+
+if __name__ == "__main__":
+    import sys
+
+    # Run all test functions
+    test_functions = [
+        test_parse_param_args_with_kwargs,
+        test_parse_param_args_with_positional,
+        test_parse_param_args_empty,
+        test_find_param_at_position,
+        test_find_param_at_position_string,
+        test_find_param_at_position_not_found,
+        test_find_all_params_in_document,
+        test_find_parameterized_classes,
+        test_build_hover_content,
+        test_build_hover_content_unknown_type,
+        test_param_type_info_completeness,
+    ]
+
+    failed = 0
+    for test_fn in test_functions:
+        try:
+            test_fn()
+            print(f"✓ {test_fn.__name__}")
+        except AssertionError as e:
+            print(f"✗ {test_fn.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"✗ {test_fn.__name__}: {type(e).__name__}: {e}")
+            failed += 1
+
+    print()
+    if failed:
+        print(f"FAILED: {failed}/{len(test_functions)} tests failed")
+        sys.exit(1)
+    else:
+        print(f"PASSED: All {len(test_functions)} tests passed!")
+        sys.exit(0)

--- a/examples/param-lsp/vscode-client/extension.js
+++ b/examples/param-lsp/vscode-client/extension.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const { LanguageClient, TransportKind } = require('vscode-languageclient/node');
+
+let client;
+
+function activate(context) {
+    // Path to the Python LSP server - use absolute path
+    const serverPath = '/home/jovyan/repos/private/holoviz-mcp/examples/param-lsp/param_lsp.py';
+
+    console.log('Starting Param LSP server:', serverPath);
+
+    const serverOptions = {
+        command: 'python',
+        args: [serverPath],
+        transport: TransportKind.stdio
+    };
+
+    const clientOptions = {
+        // Register for Python files
+        documentSelector: [{ scheme: 'file', language: 'python' }],
+        synchronize: {
+            // Watch for .py file changes
+            fileEvents: require('vscode').workspace.createFileSystemWatcher('**/*.py')
+        }
+    };
+
+    // Create and start the language client
+    client = new LanguageClient(
+        'param-lsp',
+        'Param LSP',
+        serverOptions,
+        clientOptions
+    );
+
+    client.start();
+    console.log('Param LSP client started');
+}
+
+function deactivate() {
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
+}
+
+module.exports = { activate, deactivate };

--- a/examples/param-lsp/vscode-client/package.json
+++ b/examples/param-lsp/vscode-client/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "param-lsp-client",
+  "displayName": "Param LSP",
+  "description": "Language support for param.Parameterized classes",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "activationEvents": [
+    "onLanguage:python"
+  ],
+  "main": "./extension.js",
+  "contributes": {},
+  "dependencies": {
+    "@vscode/vsce": "^3.7.1",
+    "vscode-languageclient": "^9.0.1"
+  }
+}


### PR DESCRIPTION
Just vibe code a param LSP server to better understand what is possible and what it could help with.

The extension installed

<img width="574" height="238" alt="image" src="https://github.com/user-attachments/assets/09f30d0c-32cb-49f6-b8d7-afab758dd39e" />

Hover over class attribute provides parameter details

<img width="861" height="311" alt="image" src="https://github.com/user-attachments/assets/da6ce7a5-1429-4ece-806a-88c3744cd266" />

Hover over instance attribute provides parameter details

<img width="817" height="383" alt="image" src="https://github.com/user-attachments/assets/f2bb861a-07f7-4fb2-b468-7a1e55c5be75" />


