### PR TITLE
Enhancement/browser tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/explanation/tools.md
+++ b/docs/explanation/tools.md
@@ -75,28 +75,36 @@ Tools for discovering and working with Panel components.
 
 **Demo**: [https://awesome-panel-holoviz-mcp-ui.hf.space/panel_get_component_parameters](https://awesome-panel-holoviz-mcp-ui.hf.space/panel_get_component_parameters)
 
-### panel_take_screenshot
+### panel_inspect_app
 
-**Purpose**: Take a screenshot of your (panel) web app.
+**Purpose**: Inspect your (Panel) web app by capturing a screenshot and/or browser console logs.
 
 **Parameters**:
-- `url` (string): The url to take the screenshot of. Default is 'http://localhost:5006/'
+- `url` (string): The URL to inspect. Default is `http://localhost:5006/`
 - `width` (int): The width of the browser viewport. Default is 1920
 - `height` (int): The height of the browser viewport. Default is 1200
 - `full_page` (bool): Whether to capture the full scrollable page. Default is False
-- `delay` (int): Seconds to wait after page load before taking the screenshot. Default is 2
-- `save_screenshot` (bool | string): Whether and where to save the screenshot to disk. Default is True
+- `delay` (int): Seconds to wait after page load before capturing. Default is 2
+- `save_screenshot` (bool | string): Whether and where to save the screenshot to disk. Default is False
   - `True`: Save to default screenshots directory (`~/.holoviz-mcp/screenshots/`) with auto-generated filename
   - `False`: Don't save screenshot to disk (only return to AI)
   - `string`: Save to specified absolute path (raises ValueError if path is not absolute)
+- `screenshot` (bool): Whether to capture a screenshot. Default is True
+- `console_logs` (bool): Whether to capture browser console logs. Default is True
+- `log_level` (string, optional): Filter console logs by level (e.g., `"error"`, `"warning"`, `"log"`)
 
-**Use Case**: Understand how the app looks and save screenshots for later review
+**Use Case**: Understand how the app looks, debug JavaScript errors, and inspect browser console output — all in a single call.
 
-**Returns**: ImageContent (screenshot image returned to AI).
+**Returns**: A list containing:
+- `ImageContent` (screenshot) when `screenshot=True`
+- `TextContent` (console logs as JSON) when `console_logs=True`
 
-**Note**: When `save_screenshot=True` or a path is provided, the screenshot is also saved to disk with a timestamp-based filename (e.g., `screenshot_2026-02-09_12-01-03_abc123.png`).
+**Note**: At least one of `screenshot` or `console_logs` must be True. When `save_screenshot=True` or a path is provided, the screenshot is also saved to disk with a timestamp-based filename (e.g., `screenshot_2026-02-09_12-01-03_abc123.png`).
 
-**Example Query**: *"Take a screenshot of http://127.0.0.1:8000/"**
+**Example Queries**:
+- *"Take a screenshot of http://127.0.0.1:8000/"*
+- *"Check my Panel app for JavaScript errors"*
+- *"Show me the console errors from my app"*
 
 ## HoloViews Tool
 

--- a/src/holoviz_mcp/config/config.yaml
+++ b/src/holoviz_mcp/config/config.yaml
@@ -167,6 +167,24 @@ docs:
       folders:
         docs/bokeh/source/docs:
           url_path: "/"
+    panel-live:
+      url: "https://github.com/panel-extensions/panel-live.git"
+      branch: main
+      url_transform: "plotly"
+      folders:
+        docs:
+          url_path: ""
+      base_url: "https://panel-extensions.github.io/panel-live"
+      reference_patterns: []
+    panel-reactflow:
+      url: "https://github.com/panel-extensions/panel-reactflow.git"
+      branch: main
+      url_transform: "plotly"
+      folders:
+        docs:
+          url_path: ""
+      base_url: "https://panel-extensions.github.io/panel-reactflow"
+      reference_patterns: []
 
   index_patterns:
     - "**/*.md"

--- a/src/holoviz_mcp/config/models.py
+++ b/src/holoviz_mcp/config/models.py
@@ -150,7 +150,7 @@ class ServerConfig(BaseModel):
         default_factory=lambda: (_holoviz_mcp_user_dir() / "vector_db" / "chroma").expanduser(), description="Path to the Chroma vector database."
     )
     screenshots_dir: Path = Field(
-        default_factory=lambda: (_holoviz_mcp_user_dir() / "screenshots").expanduser(), description="Directory for saving screenshots from panel_take_screenshot tool."
+        default_factory=lambda: (_holoviz_mcp_user_dir() / "screenshots").expanduser(), description="Directory for saving screenshots from panel_inspect_app tool."
     )
 
 

--- a/src/holoviz_mcp/panel_mcp/models.py
+++ b/src/holoviz_mcp/panel_mcp/models.py
@@ -122,3 +122,11 @@ class ComponentDetails(ComponentSummary):
             package=self.package,
             description=self.description,
         )
+
+
+class ConsoleLogEntry(BaseModel):
+    """A single browser console log entry captured during app inspection."""
+
+    level: str = Field(description="Console message level: 'log', 'info', 'warning', 'error', 'debug', etc.")
+    message: str = Field(description="The text content of the console message.")
+    timestamp: Optional[str] = Field(default=None, description="ISO 8601 timestamp when the message was captured.")

--- a/src/holoviz_mcp/panel_mcp/server.py
+++ b/src/holoviz_mcp/panel_mcp/server.py
@@ -10,6 +10,7 @@ Use this server to access:
 
 import asyncio
 import atexit
+import json
 import logging
 from asyncio import sleep
 from datetime import datetime
@@ -21,12 +22,14 @@ from fastmcp import Context
 from fastmcp import FastMCP
 from fastmcp.utilities.types import Image
 from mcp.types import ImageContent
+from mcp.types import TextContent
 
 from holoviz_mcp.config.loader import get_config
 from holoviz_mcp.panel_mcp.data import get_components as _get_components_org
 from holoviz_mcp.panel_mcp.models import ComponentDetails
 from holoviz_mcp.panel_mcp.models import ComponentSummary
 from holoviz_mcp.panel_mcp.models import ComponentSummarySearchResult
+from holoviz_mcp.panel_mcp.models import ConsoleLogEntry
 from holoviz_mcp.panel_mcp.models import ParameterInfo
 
 # Create the FastMCP server
@@ -502,21 +505,29 @@ def _get_playwright_manager() -> PlaywrightManager:
 
 
 @mcp.tool()
-async def take_screenshot(
+async def inspect_app(
     url: str = "http://localhost:5006/",
     width: int = 1920,
     height: int = 1200,
     full_page: bool = False,
     delay: int = 2,
     save_screenshot: bool | str = False,
-) -> ImageContent:
+    screenshot: bool = True,
+    console_logs: bool = True,
+    log_level: str | None = None,
+) -> list[TextContent | ImageContent]:
     """
-    Take a screenshot of the specified url.
+    Inspect a running Panel app by capturing a screenshot and/or browser console logs.
+
+    Panel apps (especially custom components) often have JavaScript errors that are
+    invisible to users and LLMs. This tool captures both a visual screenshot and the
+    browser console output in a single call, making it easy to diagnose rendering
+    issues, JS errors, and runtime warnings.
 
     Arguments
     ----------
     url : str, default="http://localhost:5006/"
-        The URL of the page to take a screenshot of.
+        The URL of the page to inspect.
     width : int, default=1920
         The width of the browser viewport.
     height : int, default=1200
@@ -524,57 +535,99 @@ async def take_screenshot(
     full_page : bool, default=False
         Whether to capture the full scrollable page.
     delay : int, default=2
-        Seconds to wait after page load before taking the screenshot, to allow dynamic content to render.
+        Seconds to wait after page load before capturing, to allow dynamic content to render.
     save_screenshot : bool | str, default=False
         Whether and where to save the screenshot to disk:
         - True: Save to default screenshots directory (~/.holoviz-mcp/screenshots/) with auto-generated filename
         - False: Don't save screenshot to disk (only return to AI)
         - str: Save to specified absolute path (raises ValueError if path is not absolute)
+    screenshot : bool, default=True
+        Whether to capture a screenshot of the page.
+    console_logs : bool, default=True
+        Whether to capture browser console log messages.
+    log_level : str | None, default=None
+        Filter console logs by level. If None, all levels are captured.
+        Common levels: 'log', 'info', 'warning', 'error', 'debug'.
     """
+    if not screenshot and not console_logs:
+        raise ValueError("At least one of 'screenshot' or 'console_logs' must be True.")
+
     manager = _get_playwright_manager()
     browser = await manager.get_browser()
     page = await browser.new_page(
         ignore_https_errors=True,
         viewport={"width": width, "height": height},
     )
+
+    # Collect console log entries
+    collected_logs: list[ConsoleLogEntry] = []
+
+    if console_logs:
+
+        def _on_console(msg):
+            collected_logs.append(
+                ConsoleLogEntry(
+                    level=msg.type,
+                    message=msg.text,
+                    timestamp=datetime.now().isoformat(),
+                )
+            )
+
+        page.on("console", _on_console)
+
     try:
         await page.goto(url, wait_until="networkidle")
         await sleep(delay=delay)
-        buffer = await page.screenshot(type="png", full_page=full_page)
+        buffer = await page.screenshot(type="png", full_page=full_page) if screenshot else None
     finally:
         await page.close()
 
-    # Coerce string "false"/"true" to bool (MCP clients may serialize bools as strings)
-    if isinstance(save_screenshot, str) and save_screenshot.lower() in ("true", "false"):
-        save_screenshot = save_screenshot.lower() == "true"
+    result: list[TextContent | ImageContent] = []
 
-    # Handle screenshot saving
-    if save_screenshot:
-        if isinstance(save_screenshot, str):
-            # Custom path specified
-            save_path = Path(save_screenshot)
-            if not save_path.is_absolute():
-                raise ValueError(f"save_screenshot path must be absolute, got: {save_screenshot}")
-        else:
-            # Default path - use screenshots_dir from config
-            screenshots_dir = _config.server.screenshots_dir
-            screenshots_dir.mkdir(parents=True, exist_ok=True)
+    # Handle screenshot saving and result
+    if screenshot and buffer is not None:
+        # Coerce string "false"/"true" to bool (MCP clients may serialize bools as strings)
+        save = save_screenshot
+        if isinstance(save, str) and save.lower() in ("true", "false"):
+            save = save.lower() == "true"
 
-            # Generate filename with timestamp and UUID
-            timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            unique_id = str(uuid4())[:8]
-            filename = f"screenshot_{timestamp}_{unique_id}.png"
-            save_path = screenshots_dir / filename
+        if save:
+            if isinstance(save, str):
+                # Custom path specified
+                save_path = Path(save)
+                if not save_path.is_absolute():
+                    raise ValueError(f"save_screenshot path must be absolute, got: {save_screenshot}")
+            else:
+                # Default path - use screenshots_dir from config
+                screenshots_dir = _config.server.screenshots_dir
+                screenshots_dir.mkdir(parents=True, exist_ok=True)
 
-        # Ensure parent directory exists
-        save_path.parent.mkdir(parents=True, exist_ok=True)
+                # Generate filename with timestamp and UUID
+                timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+                unique_id = str(uuid4())[:8]
+                filename = f"screenshot_{timestamp}_{unique_id}.png"
+                save_path = screenshots_dir / filename
 
-        # Write the screenshot to disk
-        save_path.write_bytes(buffer)
-        logger.info(f"Screenshot saved to: {save_path}")
+            # Ensure parent directory exists
+            save_path.parent.mkdir(parents=True, exist_ok=True)
 
-    image = Image(data=buffer, format="png")
-    return image.to_image_content()
+            # Write the screenshot to disk
+            save_path.write_bytes(buffer)
+            logger.info(f"Screenshot saved to: {save_path}")
+
+        image = Image(data=buffer, format="png")
+        result.append(image.to_image_content())
+
+    # Handle console logs result
+    if console_logs:
+        filtered_logs = collected_logs
+        if log_level is not None:
+            filtered_logs = [entry for entry in collected_logs if entry.level == log_level]
+
+        logs_json = json.dumps([entry.model_dump() for entry in filtered_logs], indent=2)
+        result.append(TextContent(type="text", text=logs_json))
+
+    return result
 
 
 if __name__ == "__main__":

--- a/tests/test_panel_mcp.py
+++ b/tests/test_panel_mcp.py
@@ -17,9 +17,12 @@ rather than mocking dependencies, providing confidence that the MCP server
 works correctly with actual Panel installations.
 """
 
+import json
+
 import pytest
 from fastmcp import Client
 from mcp.types import ImageContent
+from mcp.types import TextContent
 
 from holoviz_mcp.panel_mcp.server import mcp
 
@@ -243,7 +246,7 @@ class TestPanelMCPIntegration:
             "search_components",
             "get_component",
             "get_component_parameters",
-            "take_screenshot",
+            "inspect_app",
         ]
 
         for tool in expected_tools:
@@ -318,165 +321,161 @@ class TestPanelMCPIntegration:
                 # The actual structure depends on the implementation
 
     @pytest.mark.asyncio
-    async def test_take_screenshot_returns_image(self):
-        """Test the take_screenshot tool returns an image payload."""
+    async def test_inspect_app_returns_screenshot_and_logs(self):
+        """Test inspect_app returns both screenshot and console logs by default."""
+        pytest.importorskip("playwright.async_api")
 
-        playwright = pytest.importorskip("playwright.async_api")
+        import holoviz_mcp.panel_mcp.server as _srv
 
-        # Skip cleanly if the browser binary is not available
-        async with playwright.async_playwright() as p:
-            try:
-                browser = await p.chromium.launch(headless=True)
-                await browser.close()
-            except Exception as exc:  # pragma: no cover - defensive skip
-                pytest.skip(f"Playwright chromium not available: {exc}")
+        # Reset the PlaywrightManager singleton so the browser is created
+        # in the current event loop context (avoids stale cross-context refs).
+        if _srv._playwright_manager is not None:
+            await _srv._playwright_manager.close()
+            _srv._playwright_manager = None
 
         client = Client(mcp)
         async with client:
-            url = "data:text/html,<html><body><h1>Screenshot</h1></body></html>"
-            result = await client.call_tool("take_screenshot", {"url": url})
+            url = "data:text/html,<html><body><h1>Hello</h1><script>console.log('hello')</script></body></html>"
+            result = await client.call_tool("inspect_app", {"url": url})
 
-        image_content = result.content[0]
+        # Should have both image and text content
+        assert len(result.content) == 2
+        assert isinstance(result.content[0], ImageContent)
+        assert isinstance(result.content[1], TextContent)
 
-        assert isinstance(image_content, ImageContent)
+        # Parse the console logs JSON
+        logs = json.loads(result.content[1].text)
+        assert isinstance(logs, list)
+        assert any(entry["message"] == "hello" for entry in logs)
+
+        # Clean up to avoid cross-test browser leaks
+        if _srv._playwright_manager is not None:
+            await _srv._playwright_manager.close()
+            _srv._playwright_manager = None
 
     @pytest.mark.asyncio
-    async def test_take_screenshot_saves_to_default_location(self):
-        """Test that take_screenshot saves to default location when save_screenshot=True."""
+    async def test_inspect_app_screenshot_only(self):
+        """Test inspect_app with console_logs=False returns only a screenshot."""
+        pytest.importorskip("playwright.async_api")
+
+        client = Client(mcp)
+        async with client:
+            url = "data:text/html,<html><body><h1>Hello</h1></body></html>"
+            result = await client.call_tool("inspect_app", {"url": url, "console_logs": False})
+
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], ImageContent)
+
+        import holoviz_mcp.panel_mcp.server as _srv
+
+        if _srv._playwright_manager is not None:
+            await _srv._playwright_manager.close()
+            _srv._playwright_manager = None
+
+    @pytest.mark.asyncio
+    async def test_inspect_app_console_logs_only(self):
+        """Test inspect_app with screenshot=False returns only console logs."""
+        pytest.importorskip("playwright.async_api")
+
+        client = Client(mcp)
+        async with client:
+            url = "data:text/html,<html><body><script>console.log('test-msg')</script></body></html>"
+            result = await client.call_tool("inspect_app", {"url": url, "screenshot": False})
+
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], TextContent)
+
+        logs = json.loads(result.content[0].text)
+        assert any(entry["message"] == "test-msg" for entry in logs)
+
+        import holoviz_mcp.panel_mcp.server as _srv
+
+        if _srv._playwright_manager is not None:
+            await _srv._playwright_manager.close()
+            _srv._playwright_manager = None
+
+    @pytest.mark.asyncio
+    async def test_inspect_app_log_level_filter(self):
+        """Test inspect_app filters console logs by level."""
+        pytest.importorskip("playwright.async_api")
+
+        client = Client(mcp)
+        async with client:
+            url = "data:text/html,<html><body><script>console.log('info-msg');console.error('err-msg')</script></body></html>"
+            result = await client.call_tool("inspect_app", {"url": url, "screenshot": False, "log_level": "error"})
+
+        assert len(result.content) == 1
+        logs = json.loads(result.content[0].text)
+        # Only error-level messages should be present
+        assert all(entry["level"] == "error" for entry in logs)
+        assert any(entry["message"] == "err-msg" for entry in logs)
+
+        import holoviz_mcp.panel_mcp.server as _srv
+
+        if _srv._playwright_manager is not None:
+            await _srv._playwright_manager.close()
+            _srv._playwright_manager = None
+
+    @pytest.mark.asyncio
+    async def test_inspect_app_both_false_raises(self):
+        """Test inspect_app raises ValueError when both screenshot and console_logs are False."""
+        pytest.importorskip("playwright.async_api")
+
+        client = Client(mcp)
+        async with client:
+            with pytest.raises(Exception) as exc_info:
+                await client.call_tool("inspect_app", {"url": "data:text/html,<html></html>", "screenshot": False, "console_logs": False})
+            assert "at least one" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_inspect_app_saves_to_default_location(self):
+        """Test that inspect_app saves screenshot to default location when save_screenshot=True."""
         import tempfile
         from pathlib import Path
 
-        playwright = pytest.importorskip("playwright.async_api")
+        pytest.importorskip("playwright.async_api")
 
-        # Skip cleanly if the browser binary is not available
-        async with playwright.async_playwright() as p:
-            try:
-                browser = await p.chromium.launch(headless=True)
-                await browser.close()
-            except Exception as exc:  # pragma: no cover - defensive skip
-                pytest.skip(f"Playwright chromium not available: {exc}")
+        import holoviz_mcp.panel_mcp.server as _srv
 
-        # Use a temporary directory for this test
         with tempfile.TemporaryDirectory() as tmpdir:
-            from holoviz_mcp.config.loader import get_config
-
-            config = get_config()
-            original_screenshots_dir = config.server.screenshots_dir
-            config.server.screenshots_dir = Path(tmpdir) / "screenshots"
+            # Patch the module-level _config directly so the tool sees the change
+            original_screenshots_dir = _srv._config.server.screenshots_dir
+            _srv._config.server.screenshots_dir = Path(tmpdir) / "screenshots"
 
             try:
                 client = Client(mcp)
                 async with client:
-                    url = "data:text/html,<html><body><h1>Screenshot</h1></body></html>"
-                    result = await client.call_tool("take_screenshot", {"url": url, "save_screenshot": True})
+                    url = "data:text/html,<html><body><h1>Hello</h1></body></html>"
+                    result = await client.call_tool("inspect_app", {"url": url, "save_screenshot": True, "console_logs": False})
 
-                # Verify image was returned
                 image_content = result.content[0]
                 assert isinstance(image_content, ImageContent)
 
-                # Verify file was saved
                 screenshots_dir = Path(tmpdir) / "screenshots"
                 assert screenshots_dir.exists()
                 saved_files = list(screenshots_dir.glob("screenshot_*.png"))
                 assert len(saved_files) == 1
                 assert saved_files[0].stat().st_size > 0
             finally:
-                config.server.screenshots_dir = original_screenshots_dir
+                _srv._config.server.screenshots_dir = original_screenshots_dir
+                if _srv._playwright_manager is not None:
+                    await _srv._playwright_manager.close()
+                    _srv._playwright_manager = None
 
     @pytest.mark.asyncio
-    async def test_take_screenshot_no_save_when_false(self):
-        """Test that take_screenshot doesn't save when save_screenshot=False."""
-        import tempfile
-        from pathlib import Path
+    async def test_inspect_app_rejects_relative_path(self):
+        """Test that inspect_app raises ValueError for relative save_screenshot paths."""
+        pytest.importorskip("playwright.async_api")
 
-        playwright = pytest.importorskip("playwright.async_api")
+        import holoviz_mcp.panel_mcp.server as _srv
 
-        # Skip cleanly if the browser binary is not available
-        async with playwright.async_playwright() as p:
-            try:
-                browser = await p.chromium.launch(headless=True)
-                await browser.close()
-            except Exception as exc:  # pragma: no cover - defensive skip
-                pytest.skip(f"Playwright chromium not available: {exc}")
-
-        # Use a temporary directory for this test
-        with tempfile.TemporaryDirectory() as tmpdir:
-            from holoviz_mcp.config.loader import get_config
-
-            config = get_config()
-            original_screenshots_dir = config.server.screenshots_dir
-            config.server.screenshots_dir = Path(tmpdir) / "screenshots"
-
-            try:
-                client = Client(mcp)
-                async with client:
-                    url = "data:text/html,<html><body><h1>Screenshot</h1></body></html>"
-                    result = await client.call_tool("take_screenshot", {"url": url, "save_screenshot": False})
-
-                # Verify image was returned
-                image_content = result.content[0]
-                assert isinstance(image_content, ImageContent)
-
-                # Verify no file was saved
-                screenshots_dir = Path(tmpdir) / "screenshots"
-                if screenshots_dir.exists():
-                    saved_files = list(screenshots_dir.glob("screenshot_*.png"))
-                    assert len(saved_files) == 0
-            finally:
-                config.server.screenshots_dir = original_screenshots_dir
-
-    @pytest.mark.asyncio
-    async def test_take_screenshot_saves_to_custom_path(self):
-        """Test that take_screenshot saves to custom absolute path."""
-        import tempfile
-        from pathlib import Path
-
-        playwright = pytest.importorskip("playwright.async_api")
-
-        # Skip cleanly if the browser binary is not available
-        async with playwright.async_playwright() as p:
-            try:
-                browser = await p.chromium.launch(headless=True)
-                await browser.close()
-            except Exception as exc:  # pragma: no cover - defensive skip
-                pytest.skip(f"Playwright chromium not available: {exc}")
-
-        # Use a temporary directory for this test
-        with tempfile.TemporaryDirectory() as tmpdir:
-            custom_path = str(Path(tmpdir) / "custom_screenshot.png")
-
+        try:
             client = Client(mcp)
             async with client:
-                url = "data:text/html,<html><body><h1>Screenshot</h1></body></html>"
-                result = await client.call_tool("take_screenshot", {"url": url, "save_screenshot": custom_path})
-
-            # Verify image was returned
-            image_content = result.content[0]
-            assert isinstance(image_content, ImageContent)
-
-            # Verify file was saved to custom path
-            assert Path(custom_path).exists()
-            assert Path(custom_path).stat().st_size > 0
-
-    @pytest.mark.asyncio
-    async def test_take_screenshot_rejects_relative_path(self):
-        """Test that take_screenshot raises ValueError for relative paths."""
-        playwright = pytest.importorskip("playwright.async_api")
-
-        # Skip cleanly if the browser binary is not available
-        async with playwright.async_playwright() as p:
-            try:
-                browser = await p.chromium.launch(headless=True)
-                await browser.close()
-            except Exception as exc:  # pragma: no cover - defensive skip
-                pytest.skip(f"Playwright chromium not available: {exc}")
-
-        client = Client(mcp)
-        async with client:
-            url = "data:text/html,<html><body><h1>Screenshot</h1></body></html>"
-            # Should raise ValueError for relative path
-            with pytest.raises(Exception) as exc_info:
-                await client.call_tool("take_screenshot", {"url": url, "save_screenshot": "./relative.png"})
-
-            # The exception should mention that path must be absolute
-            assert "absolute" in str(exc_info.value).lower()
+                with pytest.raises(Exception) as exc_info:
+                    await client.call_tool("inspect_app", {"url": "data:text/html,<html></html>", "save_screenshot": "./relative.png", "console_logs": False})
+                assert "absolute" in str(exc_info.value).lower()
+        finally:
+            if _srv._playwright_manager is not None:
+                await _srv._playwright_manager.close()
+                _srv._playwright_manager = None


### PR DESCRIPTION
## Summary

- Rename `panel_take_screenshot` to `panel_inspect_app` and extend it to capture both screenshots **and** browser console logs in a single call, making it easy to debug JavaScript errors in Panel apps (especially custom components)
- Add `panel-live` and `panel-reactflow` as built-in documentation repositories in `config.yaml`
- Update `docs/explanation/tools.md` to document the new tool name, parameters, and use cases

## Changes

### `panel_inspect_app` (renamed from `panel_take_screenshot`)

The tool now returns a `list[TextContent | ImageContent]` instead of a single `ImageContent`, with three new parameters:

| Parameter | Type | Default | Description |
|---|---|---|---|
| `screenshot` | `bool` | `True` | Whether to capture a screenshot |
| `console_logs` | `bool` | `True` | Whether to capture browser console logs |
| `log_level` | `str \| None` | `None` | Filter logs by level (`"error"`, `"warning"`, `"log"`, etc.) |

All existing parameters (`url`, `width`, `height`, `full_page`, `delay`, `save_screenshot`) are preserved unchanged.

Raises `ValueError` if both `screenshot=False` and `console_logs=False`.

### New built-in doc repositories

- **panel-live** (`panel-extensions/panel-live`)
- **panel-reactflow** (`panel-extensions/panel-reactflow`)

### Files changed

- `src/holoviz_mcp/panel_mcp/server.py` — Rename tool, add console log capture via Playwright `page.on("console")`, return mixed content list
- `src/holoviz_mcp/panel_mcp/models.py` — Add `ConsoleLogEntry` Pydantic model
- `src/holoviz_mcp/config/config.yaml` — Add `panel-live` and `panel-reactflow` repositories
- `src/holoviz_mcp/config/models.py` — Update `screenshots_dir` description to reference new tool name
- `tests/test_panel_mcp.py` — Update tests for renamed tool and add coverage for console log capture, log level filtering, and the error case
- `docs/explanation/tools.md` — Replace `panel_take_screenshot` section with `panel_inspect_app` documentation

## Test plan

- [ ] `pixi run test` — all existing and new tests pass
- [ ] `pixi run pre-commit-run` — linting, formatting, and type checks pass
- [ ] `pixi run mkdocs build --strict` — docs build without warnings
- [ ] Manually verify `panel_inspect_app` returns both screenshot and console logs against a running Panel app
- [ ] Verify `log_level` filtering returns only matching entries
- [ ] Verify `screenshot=False` returns only console logs (no image)
- [ ] Verify `console_logs=False` returns only the screenshot (no text)
- [ ] Verify `screenshot=False, console_logs=False` raises `ValueError`
