### PR TITLE
fix: resolve doc_get paths missing project-specific prefix

### DIFF
--- a/src/holoviz_mcp/holoviz_mcp/data.py
+++ b/src/holoviz_mcp/holoviz_mcp/data.py
@@ -2092,6 +2092,32 @@ class DocumentationIndexer:
         except BaseException:
             return []
 
+    def _resolve_path_by_suffix(self, path: str, project: str) -> str | None:
+        """Find a stored source_path ending with *path* when the exact lookup misses.
+
+        Returns the full path only when exactly one candidate matches; None otherwise.
+        """
+        try:
+            results = self.collection.get(
+                where={"project": project},
+                include=["metadatas"],
+            )
+            if not results["metadatas"]:
+                return None
+
+            all_paths = {_normalize_source_path(str(m.get("source_path", ""))) for m in results["metadatas"] if m.get("source_path")}
+
+            suffix = "/" + path.lstrip("/")
+            matches = [p for p in all_paths if p.endswith(suffix) or p == path]
+
+            if len(matches) == 1:
+                return matches[0]
+            return None
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except BaseException:
+            return None
+
     def _reconstruct_document_content(self, source_path: str, project: str) -> str:
         """Reconstruct full document content from its chunks in ChromaDB.
 
@@ -2418,6 +2444,13 @@ class DocumentationIndexer:
 
             # Reconstruct full content from chunks
             merged_content = self._reconstruct_document_content(normalized_path, project)
+
+            if not merged_content:
+                resolved_path = self._resolve_path_by_suffix(normalized_path, project)
+                if resolved_path:
+                    normalized_path = resolved_path
+                    merged_content = self._reconstruct_document_content(normalized_path, project)
+
             if not merged_content:
                 # Provide example paths from this project to help discoverability
                 example_paths = self._get_example_paths(project, limit=5)

--- a/src/holoviz_mcp/holoviz_mcp/server.py
+++ b/src/holoviz_mcp/holoviz_mcp/server.py
@@ -690,10 +690,7 @@ def _patch_fastmcp_skills_utf8() -> None:
             raise FileNotFoundError(f"Skill directory not found: {self._skill_path}")
 
         if not main_file.exists():
-            raise FileNotFoundError(
-                f"Main skill file not found: {main_file}. "
-                f"Expected {self._main_file_name} in {self._skill_path}"
-            )
+            raise FileNotFoundError(f"Main skill file not found: {main_file}. " f"Expected {self._main_file_name} in {self._skill_path}")
 
         content = main_file.read_text(encoding="utf-8")
         frontmatter, body = _skill_provider_module.parse_frontmatter(content)
@@ -792,6 +789,7 @@ def _add_skills_provider():
     if roots:
         provider = SkillsDirectoryProvider(roots=roots, supporting_files="resources")
         mcp.add_provider(provider)
+
 
 _add_agent_resources()
 _add_skills_provider()


### PR DESCRIPTION
closes #132 

## Verification
Ran: `pixi run pytest tests/docs_mcp/test_issue.py`
```

import pytest
from fastmcp import Client

from holoviz_mcp.holoviz_mcp.server import mcp


@pytest.mark.integration
@pytest.mark.asyncio
async def test_doc_get_without_prefix():
    """Issue #132: doc_get should resolve paths that omit the project-specific prefix."""
    client = Client(mcp)
    async with client:
        # This path omits the 'doc/' prefix that is stored in the index
        result = await client.call_tool(
            "doc_get",
            {"path": "how_to/callbacks/examples/streaming_tabulator.md", "project": "panel"},
        )
        assert result.data
        assert result.data.title
        assert result.data.content
        assert len(result.data.content) > 100


@pytest.mark.integration
@pytest.mark.asyncio
async def test_doc_get_with_prefix_still_works():
    """doc_get should continue to work with the full prefixed path."""
    client = Client(mcp)
    async with client:
        result = await client.call_tool(
            "doc_get",
            {"path": "doc/how_to/callbacks/examples/streaming_tabulator.md", "project": "panel"},
        )
        assert result.data
        assert result.data.title
        assert result.data.content


@pytest.mark.integration
@pytest.mark.asyncio
async def test_search_then_doc_get_roundtrip():
    """Verify that source_path from search results can be used directly in doc_get."""
    client = Client(mcp)
    async with client:
        # Search for streaming tabulator
        search_result = await client.call_tool(
            "search",
            {"query": "streaming tabulator callbacks", "project": "panel", "content": False, "max_results": 3},
        )
        assert search_result.data, "Search returned no results for 'streaming tabulator'"

        # Try to fetch each result using doc_get
        for doc in search_result.data:
            result = await client.call_tool(
                "doc_get",
                {"path": doc.source_path, "project": doc.project},
            )
            assert result.data, f"doc_get failed for source_path='{doc.source_path}', project='{doc.project}'"
            assert result.data.content, f"doc_get returned empty content for '{doc.source_path}'"


@pytest.mark.integration
@pytest.mark.asyncio
async def test_doc_list_then_doc_get_roundtrip_panel():
    """Verify that source_path from doc_list can always be used in doc_get for panel."""
    client = Client(mcp)
    async with client:
        # List all panel docs
        list_result = await client.call_tool("doc_list", {"project": "panel"})
        assert list_result.data, "doc_list returned no results for 'panel'"

        # Try first 5 documents
        for doc_summary in list_result.data[:5]:
            result = await client.call_tool(
                "doc_get",
                {"path": doc_summary.source_path, "project": "panel"},
            )
            assert result.data, f"doc_get failed for source_path='{doc_summary.source_path}'"
```

## output 
```
configfile: pyproject.toml
plugins: anyio-4.11.0, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function       
collected 4 items                                               

tests\docs_mcp\test_issue.py ....                         [100%]

====================== 4 passed in 2.46s ======================= 

```