### PR TITLE
Add an AI review skill to guide users

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -12,3 +12,5 @@ Perform a `git diff` from the PR branch to the main branch, and review the code 
 - [ ] imports should be at the top of the file, not inside functions unless there is a specific reason to do so (slow import, circular import, etc.)
 - [ ] understanding the full changes, is there a more efficient or cleaner way to achieve the same result?
 - [ ] consistent and readable naming conventions, e.g. if FollowUpSuggestion is used, the variable name should be follow_up_suggestion, not followup_suggestion or follow_up_suggestions (plural)
+- [ ] if necessary, ensure the feature or enhancement documented in the docs
+- [ ] avoid implicit boolean checks on pandas objects, e.g. `if df`, `if df == obj`, etc

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,14 @@
+# Review
+
+## Purpose
+Perform a `git diff` from the PR branch to the main branch, and review the code changes for potential issues, improvements, and adherence to best practices. Then provide a plan, pointing to lines of code and modules for refactoring the code to improve its quality, readability, and maintainability.
+
+## Checklist
+- [ ] when the attribute is known to be present, do not use `hasattr` & `getattr`
+- [ ] use try/except only on the clause that may raise the exception, not on the whole function
+- [ ] try to pin the exception type in the except clause, do not use a bare except
+- [ ] return or continue early to avoid deep nesting
+- [ ] anything over 3 levels of nesting should be refactored into helper functions
+- [ ] imports should be at the top of the file, not inside functions unless there is a specific reason to do so (slow import, circular import, etc.)
+- [ ] understanding the full changes, is there a more efficient or cleaner way to achieve the same result?
+- [ ] consistent and readable naming conventions, e.g. if FollowUpSuggestion is used, the variable name should be follow_up_suggestion, not followup_suggestion or follow_up_suggestions (plural)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -12,5 +12,5 @@ Perform a `git diff` from the PR branch to the main branch, and review the code 
 - [ ] DO place imports at the top of the file; DON'T place imports inside functions unless there is a specific reason (slow import, circular import, etc.).
 - [ ] DO consider the full set of changes and whether there is a more efficient or cleaner way to achieve the same result.
 - [ ] DO use consistent and readable naming conventions, e.g., if `FollowUpSuggestion` is used, the variable name should be `follow_up_suggestion`, not `followup_suggestion` or `follow_up_suggestions` (plural)
-- [ ] if necessary, ensure the feature or enhancement documented in the docs
-- [ ] avoid implicit boolean checks on pandas objects, e.g. `if df`, `if df == obj`, etc
+- [ ] DO ensure the feature or enhancement documented in the docs
+- [ ] DO NOT use implicit boolean checks on pandas objects, e.g. `if df`, `if df == obj`, etc

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -4,13 +4,13 @@
 Perform a `git diff` from the PR branch to the main branch, and review the code changes for potential issues, improvements, and adherence to best practices. Then provide a plan, pointing to lines of code and modules for refactoring the code to improve its quality, readability, and maintainability.
 
 ## Checklist
-- [ ] when the attribute is known to be present, do not use `hasattr` & `getattr`
-- [ ] use try/except only on the clause that may raise the exception, not on the whole function
-- [ ] try to pin the exception type in the except clause, do not use a bare except
-- [ ] return or continue early to avoid deep nesting
-- [ ] anything over 3 levels of nesting should be refactored into helper functions
-- [ ] imports should be at the top of the file, not inside functions unless there is a specific reason to do so (slow import, circular import, etc.)
-- [ ] understanding the full changes, is there a more efficient or cleaner way to achieve the same result?
-- [ ] consistent and readable naming conventions, e.g. if `ExampleClass` is used, the variable name should be `example_class`, not `exampleclass` or `example_classes` (plural)
+- [ ] DO avoid using `hasattr` and `getattr` when the attribute is known to be present.
+- [ ] DO apply `try`/`except` only to the clause that may raise the exception, not to the whole function.
+- [ ] DO pin the exception type in the `except` clause; DON'T use a bare `except`.
+- [ ] DO return or continue early to avoid deep nesting.
+- [ ] DO refactor code with more than three levels of nesting into helper functions.
+- [ ] DO place imports at the top of the file; DON'T place imports inside functions unless there is a specific reason (slow import, circular import, etc.).
+- [ ] DO consider the full set of changes and whether there is a more efficient or cleaner way to achieve the same result.
+- [ ] DO use consistent and readable naming conventions, e.g., if `FollowUpSuggestion` is used, the variable name should be `follow_up_suggestion`, not `followup_suggestion` or `follow_up_suggestions` (plural)
 - [ ] if necessary, ensure the feature or enhancement documented in the docs
 - [ ] avoid implicit boolean checks on pandas objects, e.g. `if df`, `if df == obj`, etc

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -11,6 +11,6 @@ Perform a `git diff` from the PR branch to the main branch, and review the code 
 - [ ] anything over 3 levels of nesting should be refactored into helper functions
 - [ ] imports should be at the top of the file, not inside functions unless there is a specific reason to do so (slow import, circular import, etc.)
 - [ ] understanding the full changes, is there a more efficient or cleaner way to achieve the same result?
-- [ ] consistent and readable naming conventions, e.g. if FollowUpSuggestion is used, the variable name should be follow_up_suggestion, not followup_suggestion or follow_up_suggestions (plural)
+- [ ] consistent and readable naming conventions, e.g. if `ExampleClass` is used, the variable name should be `example_class`, not `exampleclass` or `example_classes` (plural)
 - [ ] if necessary, ensure the feature or enhancement documented in the docs
 - [ ] avoid implicit boolean checks on pandas objects, e.g. `if df`, `if df == obj`, etc

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -13,4 +13,6 @@ Perform a `git diff` from the PR branch to the main branch, and review the code 
 - [ ] DO consider the full set of changes and whether there is a more efficient or cleaner way to achieve the same result.
 - [ ] DO use consistent and readable naming conventions, e.g., if `FollowUpSuggestion` is used, the variable name should be `follow_up_suggestion`, not `followup_suggestion` or `follow_up_suggestions` (plural)
 - [ ] DO ensure the feature or enhancement documented in the docs
-- [ ] DO NOT use implicit boolean checks on pandas objects, e.g. `if df`, `if df == obj`, etc
+- [ ] DO minimize magic numbers; try to add an option to customize it if possible
+- [ ] DO parameterize tests
+- [ ] DO test for NaN and datetime types (np, pd)


### PR DESCRIPTION
After a user finishes prompting the LLM, prior to creating a PR, they should use this skill to do a quick review, like pre-commit.